### PR TITLE
KSP 1.1 changes

### DIFF
--- a/SolverEngines/EngineModule.cs
+++ b/SolverEngines/EngineModule.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using KSP.UI.Screens;
 using System.Reflection;
 
 
@@ -55,7 +56,7 @@ namespace SolverEngines
         // internals
         protected double tempRatio = 0d, engineTemp = 288.15d;
         protected double lastPropellantFraction = 1d;
-        protected VInfoBox overheatBox = null;
+        protected ProtoStageIconInfo overheatBox = null;
 
         protected List<ModuleAnimateHeat> emissiveAnims;
 
@@ -324,7 +325,7 @@ namespace SolverEngines
 
                 massFlow = fuelFlow * 0.001d * TimeWarp.fixedDeltaTime; // in tons
 
-                if (CheatOptions.InfiniteFuel == true)
+                if (CheatOptions.InfinitePropellant == true)
                 {
                     lastPropellantFraction = 1d;
                     UnFlameout();

--- a/SolverEngines/EnginesGUI/FlightGUI.cs
+++ b/SolverEngines/EnginesGUI/FlightGUI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using KSP.UI.Screens;
 using KSP;
 
 // Parts of this file are taken from FerramAerospaceResearch, Copyright 2015, Michael Ferrara, aka Ferram4, used with permission


### PR DESCRIPTION
# DO NOT ACCEPT THIS PULL REQUEST UNTIL READY

Updates SolverEngines for KSP 1.1

**Important**: These are the code changes, but there are reference changes as well.  I didn't make push those changes because I use Xamarin and no doubt keep my references in a different spot.

```
<ItemGroup>
<Reference Include="KSPUtil">
  <HintPath>..\..\..\Managed\KSPUtil.dll</HintPath>
</Reference>
<Reference Include="UnityEngine.UI">
  <HintPath>..\..\..\Managed\UnityEngine.UI.dll</HintPath>
</Reference>
</ItemGroup>
```
