### PR TITLE
Fix for alternator issue

### DIFF
--- a/SolverEngines/EngineModule.cs
+++ b/SolverEngines/EngineModule.cs
@@ -361,7 +361,7 @@ namespace SolverEngines
             get
             {
                 // for now changed to throttle, but clamped...
-                float tmpOutput = 0.25f + currentThrottle * 0.75f;
+                float tmpOutput = currentThrottle;
 
                 //current throttle should never allow it to go out of 0 - 1 bounds, but if it does....
                 if (tmpOutput < 0)


### PR DESCRIPTION
* Fixes issue where an alternator on a part using a ModuleEnginesSolver derived engine would have a minimum alternator output of 25% of its maximum output. (i.e., if your engine outputs 8 EC then at 0% throttle it puts out 2 EC)