### PR TITLE
Always refresh lastPropellantFraction on engine ignite.

### DIFF
--- a/SolverEngines/EngineModule.cs
+++ b/SolverEngines/EngineModule.cs
@@ -158,7 +158,11 @@ namespace SolverEngines
             }
 
             if (EngineIgnited && !flameout)
+            {
                 requestedThrottle = vessel.ctrlState.mainThrottle;
+                UpdatePropellantStatus();
+                lastPropellantFraction = PropellantAvailable() ? 1d : 0d;
+            }
             UpdateThrottle();
 
             UpdateFlightCondition();
@@ -259,9 +263,6 @@ namespace SolverEngines
             engineTemp = engineSolver.GetEngineTemp();
             tempRatio = engineTemp / maxEngineTemp;
             engineTempString = engineTemp.ToString("N0") + " K / " + maxEngineTemp.ToString("n0") + " K";
-
-            if (EngineIgnited) // slow, so only do this if we have to.
-                UpdatePropellantStatus();
 
             double thrustIn = engineSolver.GetThrust(); //in N
             double isp = engineSolver.GetIsp();
@@ -422,10 +423,7 @@ namespace SolverEngines
             flameout = false;
 
             UpdatePropellantStatus();
-            if (PropellantAvailable())
-                lastPropellantFraction = 1d;
-            else
-                lastPropellantFraction = 0d;
+            lastPropellantFraction = PropellantAvailable() ? 1d : 0d;
         }
         
         #endregion


### PR DESCRIPTION
Fixes KSP-RO/SolverEngines#28.

It seemed to me whenever we wanted to UpdatePropellantStatus() it would be smart to also update our cached lastPropellentFraction. Otherwise the only way to get lastPropellantFraction off of 0 (in the case of running tanks dry) is to shutdown and re-activate engines. Not being familiar with this code, I bet there's a better way to fix KSP-RO/SolverEngines#28 but I took a shot.